### PR TITLE
Several parts of the code need boost_system, but don't explicitly

### DIFF
--- a/crunch/Makefile
+++ b/crunch/Makefile
@@ -23,7 +23,7 @@ PERFMASKOBJECTS = perfmask.o realignutils.o utils.o smoothutils.o matrixutils.o\
 INCDIRS += -I/usr/local/include/octave
 LIBDIRS += -L/usr/local/lib/octave
 
-LIBS =$(LDFLAGS) $(LIBDIRS) -lm -lvbglm -lvbprefs -lvbio -lvbutil -lz -lpng $(DLLIB) $(GSL_LIBS)
+LIBS =$(LDFLAGS) -Wl,--no-as-needed $(LIBDIRS) -lm -lvbglm -lvbprefs -lvbio -lvbutil -lz -lpng $(DLLIB) $(GSL_LIBS) -lboost_system
 OCTLIBS = $(LIBS) -loctave -lcruft $(FORTLIB)
 
 ALLBINS=vbmm2 vbmakeglm vbmakefilter #realign norm

--- a/fileformats/Makefile
+++ b/fileformats/Makefile
@@ -6,7 +6,7 @@ include ../make_stuff.txt
 
 SHAREDFLAG=-shared
 
-LIBS=$(LDFLAGS) $(LIBDIRS) -lvbio -lvbutil -lvbprefs -lz -lpng -lgsl -lgslcblas
+LIBS=$(LDFLAGS) -Wl,--no-as-needed $(LIBDIRS) -lvbio -lvbutil -lvbprefs -lz -lpng -lgsl -lgslcblas -lboost_system
 
 ALLBINS=dcmsplit dicominfo ffinfo vbrename analyzeinfo niftiinfo
 BINS=$(ALLBINS)

--- a/gdscript/Makefile
+++ b/gdscript/Makefile
@@ -13,7 +13,7 @@ ONEOVERFDIR=../utils
 GDS_OBJECTS = gds_main.o gds.o
 
 # miscellaneous flags and such
-LIBS = $(LDFLAGS) $(LIBDIRS) $(DLLIB) -lm -lvbprefs -lvbglm -lvbio -lvbutil -lz -lpng $(GSL_LIBS)
+LIBS = $(LDFLAGS) -Wl,--no-as-needed $(LIBDIRS) $(DLLIB) -lm -lvbprefs -lvbglm -lvbio -lvbutil -lz -lpng $(GSL_LIBS) -lboost_system
 
 ALLBINS=gds
 ifeq ($(VB_TARGET),all)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -57,43 +57,43 @@ libvbio.a: $(IOOBJECTS) $(FFOBJECTS)
 	ranlib libvbio.a
 
 libvbio.so: $(IOOBJECTS) $(FFOBJECTS) libvbprefs.so libvbutil.so
-	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. -lc -lz -lgsl -lpng -lvbprefs -lvbutil $^
+	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. $^ -lc -lz -lgsl -lpng -lvbprefs -lvbutil -lboost_system
 
 libvbutil.a: $(UTILOBJECTS)
 	ar rc libvbutil.a $^
 	ranlib libvbutil.a
 
 libvbutil.so: $(UTILOBJECTS)
-	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -lc -lz $^
+	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) $^ -lc -lz -lboost_system
 
 libvbprefs.a: $(VBPOBJECTS)
 	ar rc libvbprefs.a $^
 	ranlib libvbprefs.a
 
 libvbprefs.so: $(VBPOBJECTS) libvbutil.so
-	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. -lc -lvbutil $^
+	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. $^ -lc -lvbutil -lboost_system
 
 libvbscripts.a: $(SCRIPTOBJECTS)
 	ar rc libvbscripts.a $^
 	ranlib libvbscripts.a
 
 libvbscripts.so: $(SCRIPTOBJECTS) libvbprefs.so libvbutil.so
-	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. -lc -lvbprefs -lvbutil $^
+	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. $^ -lc -lvbprefs -lvbutil
 
 libvbglm.a: $(GLMOBJECTS)
 	ar rc libvbglm.a $^
 	ranlib libvbglm.a
 
 libvbglm.so: $(GLMOBJECTS) libvbio.so libvbutil.so libvbprefs.so
-#	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. -lc -lgsl -lvbio -lvbutil -lvbscripts -lvbprefs $^
-	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. -lc -lgsl -lvbio -lvbutil -lvbprefs $^
+#	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. $^ -lc -lgsl -lvbio -lvbutil -lvbscripts -lvbprefs
+	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. $^ -lc -lgsl -lvbio -lvbutil -lvbprefs -lboost_system
 
 libdbutil.a: $(DBOBJECTS)
 	ar rc libdbutil.a $^
 	ranlib libdbutil.a
 
 libdbutil.so: $(DBOBJECTS) libvbio.so libvbutil.so
-	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. -lc -lvbio -lvbutil $^
+	g++ -shared -Wl,-soname,$@ -o $@ $(LDFLAGS) -L. $^ -lc -lvbio -lvbutil
 
 # and now for the building blocks
 

--- a/munge/Makefile
+++ b/munge/Makefile
@@ -8,7 +8,7 @@ VBLIBS=$(VBLIBS2)
 
 # miscellaneous flags and such
 
-LIBS =$(LDFLAGS) $(LIBDIRS) $(LIBPATHS) -lvbglm -lvbprefs -lvbio -lvbutil -lz -lpng $(DLLIB) $(GSL_LIBS)
+LIBS =$(LDFLAGS) -Wl,--no-as-needed $(LIBDIRS) $(LIBPATHS) -lvbglm -lvbprefs -lvbio -lvbutil -lz -lpng $(DLLIB) $(GSL_LIBS) -lboost_system
 
 CONVERTERS=tes2cub vb2cub vb2img vb2imgs vb2tes vb2vmp vbconv
 MUNGERS=vbmunge vbcmp vbshift vbsmooth vbmaskmunge vecsplit vbinterpolate vbthresh

--- a/qtglm/Makefile
+++ b/qtglm/Makefile
@@ -20,7 +20,7 @@ TCALC_OBJECTS= vbtcalc.o
 PERMGEN_OBJECTS= vbpermgen.o
 
 # miscellaneous flags and such
-LIBS=$(LDFLAGS) $(LIBDIRS) $(QTLIBDIRS) $(QTLIBS) -lz -lvbglm -lvbprefs -lvbio -lvbutil -lz $(GSL_LIBS) $(DLLIB)
+LIBS=$(LDFLAGS) -Wl,--no-as-needed $(LIBDIRS) $(QTLIBDIRS) $(QTLIBS) -lz -lvbglm -lvbprefs -lvbio -lvbutil -lz $(GSL_LIBS) $(DLLIB) -lboost_system
 
 ALLBINS= glm gdw vecview vbpermgen vbtcalc
 OSXTRA=glm.app glm.dmg gdw.app gdw.dmg vecview.app vecview.dmg vbpermgen.app vbpermgen.dmg vbtcalc.app vbtcalc.dmg

--- a/resample/Makefile
+++ b/resample/Makefile
@@ -11,7 +11,7 @@ VBTRANSFORMOBJECTS = vbtransform.o
 
 # miscellaneous flags and such
 
-LIBS = $(LDFLAGS) $(LIBDIRS) -lm -lvbprefs -lvbio -lvbutil -lz -lpng $(DLLIB) $(GSL_LIBS)
+LIBS = $(LDFLAGS) -Wl,--no-as-needed $(LIBDIRS) -lm -lvbprefs -lvbio -lvbutil -lz -lpng $(DLLIB) $(GSL_LIBS) -lboost_system
 
 # resample is in all packages
 BINS=resample

--- a/stand_alone/Makefile
+++ b/stand_alone/Makefile
@@ -13,7 +13,7 @@ TESJOIN_OBJECTS=$(TESPLIT_OBJECTS)
 REGRESSION_OBJECTS=regression.o utils.o koshutil.o
 PERMUTATION_OBJECTS=perm.o utils.o time_series_avg.o koshutil.o
 
-LIBS=$(LDFLAGS) $(LIBDIRS) -lvbglm -lvbprefs -lvbio -lvbutil -lz -lpng $(GSL_LIBS) $(DLLIB)
+LIBS=$(LDFLAGS) -Wl,--no-as-needed $(LIBDIRS) -lvbglm -lvbprefs -lvbio -lvbutil -lz -lpng $(GSL_LIBS) $(DLLIB) -lboost_system
 
 ALLBINS= calcgs calcps sliceacq tesplit tesjoin makematkg makematk\
 		comptraces permstep vbregress vbpermmat

--- a/stats/Makefile
+++ b/stats/Makefile
@@ -8,7 +8,7 @@ VBLIBS=$(VBLIBS2)
 
 # miscellaneous flags and such
 
-LIBS = $(LDFLAGS) $(LIBDIRS) -lm -lvbprefs -lvbglm -lvbio -lvbutil -lz -lpng $(DLLIB) $(GSL_LIBS)
+LIBS = $(LDFLAGS) -Wl,--no-as-needed $(LIBDIRS) -lm -lvbprefs -lvbglm -lvbio -lvbutil -lz -lpng $(DLLIB) $(GSL_LIBS) -lboost_system
 
 ALLBINS=vbvolregress vbmakeregress vbstatmap vbdumpstats glminfo vbperminfo
 ALLBINS+=vbxts vbtmap vbxmap vbmakeresid vbfdr vbpermvec vbscoregen vbmap

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -7,7 +7,7 @@ include ../make_stuff.txt
 # Some variables
 MYLIBVOXBO=../lib
 
-LIBS = $(LDFLAGS) $(LIBDIRS) -lvbglm -lvbprefs -lvbio -lvbutil -lz -lpng $(DLLIB) $(GSL_LIBS)
+LIBS = $(LDFLAGS) -Wl,--no-as-needed $(LIBDIRS) -lvbglm -lvbprefs -lvbio -lvbutil -lz -lpng $(DLLIB) $(GSL_LIBS) -lboost_system
 
 ALLBINS=vbfit vbcfx txt2num gcheck sortmvpm
 ifeq ($(VB_TARGET),all)

--- a/vbview/Makefile
+++ b/vbview/Makefile
@@ -11,7 +11,7 @@ CXXFLAGS += -DQT3_SUPPORT $(QTLIBDIRS) $(QTINCDIRS)
 VBVIEW_SUBOBJECTS=vbview.o vbview_ts.o vbview_layers.o vbview_render.o vbview_io.o vbqt_masker.o vbqt_canvas.o vbqt_glmselect.o vbqt_scalewidget.o vbview_widgets.o rsrc.o
 VBVIEW_OBJECTS=vbviewmain.o $(VBVIEW_SUBOBJECTS)
 
-LIBS=$(LDFLAGS) $(LIBDIRS) $(QTLIBDIRS) -L../vbwidgets $(QTLIBS) -lvbglm -lvbprefs -lvbio -lvbutil -lz $(DLLIB) -lgsl -lgslcblas
+LIBS=$(LDFLAGS) -Wl,--no-as-needed $(LIBDIRS) $(QTLIBDIRS) -L../vbwidgets $(QTLIBS) -lvbglm -lvbprefs -lvbio -lvbutil -lz $(DLLIB) -lgsl -lgslcblas -lboost_system
 
 # right now all three programs are in all packages, so we just
 # conditionalize on ARCH

--- a/vbwidgets/Makefile
+++ b/vbwidgets/Makefile
@@ -47,7 +47,7 @@ libvbwidgets.a: $(VBWIDGET_OBJECTS)
 	ranlib libvbwidgets.a
 
 libvbwidgets.so: $(VBWIDGET_OBJECTS)
-	g++ -shared -Wl,-soname,$@ $(LDFLAGS) -o $@ -lc $^ -L../lib -lvbio -lvbutil -lvbprefs -lvbglm -lQtCore -lQt3Support -lQtGui -lgsl
+	g++ -shared -Wl,-soname,$@ $(LDFLAGS) -o $@ -lc $^ -L../lib -lvbio -lvbutil -lvbprefs -lvbglm -lQtCore -lQt3Support -lQtGui -lgsl -lboost_system
 
 moc_%.cpp : %.h
 	$(MOC) $< -o $@


### PR DESCRIPTION
add it to their respective linker commands. This causes the build to fail when
--no-copy-dt-needed entries is set, so add them to the command line.
The -Wl,--no-as-needed flag is a workaround for cgsl being underlinked, causing a
build failure in Ubuntu, where --as-needed is set as default. Arguably, this
should be resolved in cgsl, but in the meantime, this is a good workaround.

Debian bug: http://bugs.debian.org/720821
